### PR TITLE
DROOLS-1619 fix StringUtils.is[Dereferencing]Identifier() regex

### DIFF
--- a/drools-core/src/main/java/org/drools/core/util/StringUtils.java
+++ b/drools-core/src/main/java/org/drools/core/util/StringUtils.java
@@ -1146,12 +1146,12 @@ public class StringUtils {
 
     public static boolean isIdentifier(String expr) {
         return !expr.equals("true") && !expr.equals("false") &&
-               !expr.equals("null") && expr.matches("[a-zA-Z_\\$][a-zA-Z_\\$0-9]*");
+               !expr.equals("null") && expr.matches("[\\p{L}_\\$][\\p{L}_\\$\\p{N}]*");
     }
 
     public static boolean isDereferencingIdentifier(String expr) {
         return !expr.equals("true") && !expr.equals("false") &&
-               !expr.equals("null") && expr.matches("[a-zA-Z_\\$][a-zA-Z_\\$0-9\\.]*");
+               !expr.equals("null") && expr.matches("[\\p{L}_\\$][\\p{L}_\\$\\p{N}\\.]*");
     }
 
     // To be extended in the future with more comparison strategies


### PR DESCRIPTION
As I'm not kiegroup/drools maintainer, I cannot add this commit to your PR directly there.
Hence I prefer to try first incorporating it here.
This should be the least invasive fix, and it should also be backportable to Java 6 shall ever be the case, but I'll need to double check with Mario before we can merge it into master.

Can you kindly merge this PR into your branch, please?
Your PR on kiegroup/drools should then reflect accordingly to incorporate this commit.

Thanks!