### PR TITLE
[DROOLS-7090] Fixing PMML to work with in memory GeneratedResources

### DIFF
--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/main/java/org/kie/drl/engine/runtime/mapinput/service/KieRuntimeServiceDrlMapInput.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/main/java/org/kie/drl/engine/runtime/mapinput/service/KieRuntimeServiceDrlMapInput.java
@@ -34,7 +34,7 @@ public class KieRuntimeServiceDrlMapInput implements KieRuntimeService<EfestoMap
 
     @Override
     public boolean canManageInput(EfestoInput toEvaluate, EfestoRuntimeContext context) {
-        return DrlRuntimeHelper.canManage(toEvaluate);
+        return DrlRuntimeHelper.canManage(toEvaluate, context);
     }
 
     @Override

--- a/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/main/java/org/kie/drl/engine/runtime/mapinput/utils/DrlRuntimeHelper.java
+++ b/kie-drl/kie-drl-implementations/kie-drl-map-input/kie-drl-map-input-runtime/src/main/java/org/kie/drl/engine/runtime/mapinput/utils/DrlRuntimeHelper.java
@@ -44,6 +44,11 @@ public class DrlRuntimeHelper {
         return (toEvaluate instanceof AbstractEfestoInput) && (toEvaluate.getInputData() instanceof EfestoMapInputDTO) && getGeneratedExecutableResource(toEvaluate.getFRI(), "drl").isPresent();
     }
 
+    public static boolean canManage(EfestoInput toEvaluate, EfestoRuntimeContext context) {
+        return (toEvaluate instanceof AbstractEfestoInput) && (toEvaluate.getInputData() instanceof EfestoMapInputDTO) &&
+                getGeneratedExecutableResource(toEvaluate.getFRI(), context.getGeneratedResourcesMap()).isPresent();
+    }
+
     public static Optional<EfestoOutputDrlMap> execute(AbstractEfestoInput<EfestoMapInputDTO> toEvaluate, EfestoRuntimeContext context) {
         KieSession kieSession;
         try {

--- a/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/utils/PMMLLoaderUtils.java
+++ b/kie-pmml-trusty/kie-pmml-commons/src/main/java/org/kie/pmml/commons/utils/PMMLLoaderUtils.java
@@ -16,17 +16,16 @@
 package org.kie.pmml.commons.utils;
 
 import java.util.Collection;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.kie.efesto.common.api.model.FRI;
 import org.kie.efesto.common.api.model.GeneratedExecutableResource;
 import org.kie.efesto.runtimemanager.api.exceptions.KieRuntimeServiceException;
 import org.kie.pmml.api.PMMLContext;
-import org.kie.pmml.api.runtime.PMMLRuntimeContext;
 import org.kie.pmml.commons.model.KiePMMLModelFactory;
 
 import static org.kie.efesto.runtimemanager.api.utils.GeneratedResourceUtils.getGeneratedExecutableResource;
-import static org.kie.pmml.commons.Constants.PMML_STRING;
 
 public class PMMLLoaderUtils {
 
@@ -41,10 +40,13 @@ public class PMMLLoaderUtils {
 
     @SuppressWarnings("unchecked")
     public static KiePMMLModelFactory loadKiePMMLModelFactory(FRI fri, PMMLContext pmmlContext) {
-        GeneratedExecutableResource finalResource = getGeneratedExecutableResource(fri, PMML_STRING)
-                .orElseThrow(() -> new KieRuntimeServiceException("Can not find expected GeneratedExecutableResource " +
-                                                                          "for " + fri));
-        return loadKiePMMLModelFactory(finalResource, pmmlContext);
+        Optional<GeneratedExecutableResource> generatedExecutableResource = getGeneratedExecutableResource(fri, pmmlContext.getGeneratedResourcesMap());
+        if (generatedExecutableResource.isPresent()) {
+            return loadKiePMMLModelFactory(generatedExecutableResource.get(), pmmlContext);
+        } else {
+            throw new KieRuntimeServiceException("Can not find expected GeneratedExecutableResource " +
+                                                             "for " + fri);
+        }
     }
 
     public static KiePMMLModelFactory loadKiePMMLModelFactory(GeneratedExecutableResource finalResource,

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/service/KieRuntimeServicePMML.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/service/KieRuntimeServicePMML.java
@@ -38,7 +38,7 @@ public class KieRuntimeServicePMML implements KieRuntimeService<PMMLRuntimeConte
 
     @Override
     public boolean canManageInput(EfestoInput toEvaluate, PMMLRuntimeContext context) {
-        return canManage(toEvaluate);
+        return canManage(toEvaluate, context);
     }
 
     @Override

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/service/PMMLRuntimeInternalImpl.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/service/PMMLRuntimeInternalImpl.java
@@ -16,11 +16,14 @@
 package org.kie.pmml.evaluator.core.service;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.kie.api.pmml.PMML4Result;
 import org.kie.efesto.common.api.model.FRI;
+import org.kie.efesto.common.api.model.GeneratedResources;
 import org.kie.efesto.runtimemanager.api.model.EfestoOutput;
 import org.kie.efesto.runtimemanager.api.service.RuntimeManager;
 import org.kie.efesto.runtimemanager.api.utils.SPIUtils;
@@ -44,7 +47,18 @@ public class PMMLRuntimeInternalImpl implements PMMLRuntime {
 
     private static final RuntimeManager runtimeManager = SPIUtils.getRuntimeManager(true).get();
 
+    private final Map<String, GeneratedResources> generatedResourcesMap;
+
     public PMMLRuntimeInternalImpl() {
+        this(Collections.emptyMap());
+    }
+
+    public PMMLRuntimeInternalImpl(Map<String, GeneratedResources> generatedResourcesMap) {
+        this.generatedResourcesMap = generatedResourcesMap;
+    }
+
+    public Map<String, GeneratedResources> getGeneratedResourcesMap() {
+        return generatedResourcesMap;
     }
 
     @Override

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PMMLRuntimeHelper.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-core/src/main/java/org/kie/pmml/evaluator/core/utils/PMMLRuntimeHelper.java
@@ -27,6 +27,7 @@ import org.kie.api.pmml.PMMLRequestData;
 import org.kie.efesto.common.api.model.GeneratedExecutableResource;
 import org.kie.efesto.runtimemanager.api.exceptions.KieRuntimeServiceException;
 import org.kie.efesto.runtimemanager.api.model.EfestoInput;
+import org.kie.efesto.runtimemanager.api.model.EfestoRuntimeContext;
 import org.kie.pmml.api.enums.PMML_MODEL;
 import org.kie.pmml.api.enums.PMML_STEP;
 import org.kie.pmml.api.exceptions.KiePMMLException;
@@ -70,6 +71,10 @@ public class PMMLRuntimeHelper {
 
     public static boolean canManage(EfestoInput toEvaluate) {
         return (toEvaluate instanceof EfestoInputPMML) && isPresentExecutableOrRedirect(toEvaluate.getFRI(), PMML_STRING);
+    }
+
+    public static boolean canManage(EfestoInput toEvaluate, EfestoRuntimeContext runtimeContext) {
+        return (toEvaluate instanceof EfestoInputPMML) && isPresentExecutableOrRedirect(toEvaluate.getFRI(), runtimeContext);
     }
 
     public static Optional<EfestoOutputPMML> execute(EfestoInputPMML toEvaluate, PMMLRuntimeContext pmmlContext) {

--- a/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-utils/src/main/java/org/kie/pmml/evaluator/utils/PMMLRuntimeFactoryImpl.java
+++ b/kie-pmml-trusty/kie-pmml-evaluator/kie-pmml-evaluator-utils/src/main/java/org/kie/pmml/evaluator/utils/PMMLRuntimeFactoryImpl.java
@@ -47,7 +47,7 @@ public class PMMLRuntimeFactoryImpl implements PMMLRuntimeFactory {
                 new KieMemoryCompiler.MemoryCompilerClassLoader(Thread.currentThread().getContextClassLoader());
         PMMLCompilationContext pmmlContext = new PMMLCompilationContextImpl(pmmlFile.getName(), memoryCompilerClassLoader);
         compilationManager.processResource(pmmlContext, efestoFileResource);
-        return new PMMLRuntimeInternalImpl();
+        return new PMMLRuntimeInternalImpl(pmmlContext.getGeneratedResourcesMap());
     }
 
     @Override

--- a/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/src/test/java/org/kie/pmml/models/tests/AbstractPMMLTest.java
+++ b/kie-pmml-trusty/kie-pmml-models/kie-pmml-models-tests/src/test/java/org/kie/pmml/models/tests/AbstractPMMLTest.java
@@ -29,7 +29,9 @@ import org.kie.pmml.api.PMMLRuntimeFactory;
 import org.kie.pmml.api.models.PMMLStep;
 import org.kie.pmml.api.runtime.PMMLListener;
 import org.kie.pmml.api.runtime.PMMLRuntime;
+import org.kie.pmml.api.runtime.PMMLRuntimeContext;
 import org.kie.pmml.evaluator.core.PMMLRuntimeContextImpl;
+import org.kie.pmml.evaluator.core.service.PMMLRuntimeInternalImpl;
 import org.kie.pmml.evaluator.core.utils.PMMLRequestDataBuilder;
 import org.kie.pmml.evaluator.utils.SPIUtils;
 
@@ -73,8 +75,10 @@ public class AbstractPMMLTest {
         final PMMLRequestData pmmlRequestData = getPMMLRequestData(modelName, inputData);
         KieMemoryCompiler.MemoryCompilerClassLoader memoryCompilerClassLoader =
                 new KieMemoryCompiler.MemoryCompilerClassLoader(Thread.currentThread().getContextClassLoader());
-        return pmmlRuntime.evaluate(modelName, new PMMLRuntimeContextImpl(pmmlRequestData, fileName, pmmlListeners,
-                                                                          memoryCompilerClassLoader));
+        PMMLRuntimeContext context = new PMMLRuntimeContextImpl(pmmlRequestData, fileName, pmmlListeners,
+                                                             memoryCompilerClassLoader);
+        context.getGeneratedResourcesMap().putAll(((PMMLRuntimeInternalImpl)pmmlRuntime).getGeneratedResourcesMap());
+        return pmmlRuntime.evaluate(modelName, context);
     }
 
     protected PMMLListenerTest getPMMLListener() {


### PR DESCRIPTION
Hi @tkobayas 
This PR fixes the PMML-related issues I found in the drools build.
I have found the following issues that IMO should be fixed:
1) there are some  `GeneratedResourceUtils` methods (like `isPresentExecutableOrRedirect(FRI fri, String modelType)`) that implicitily looks for GeneratedResources inside the `IndexFile`; this is become a big source of bug, because all the client code now is "unaware" of that and brokes randomly (or it must be fixed one by one); I think it would be better to change all those public methods to accept the "Context", and implement only methods that looks for generated reources inside the context
2) similarly, there are some utility methods (like `DrlRuntimeHelper.canManage(EfestoInput toEvaluate)`) that in the same way implicitily looks for GeneratedResources inside the `IndexFile; I think that as for the previous point, also those methods should be removed (I guess they will become "self-evident" when point 1 is done)

Wdyt ?

P.S. this PR is just a partial fix
